### PR TITLE
Fix for azure "bad gateway"

### DIFF
--- a/src/ProxyKit.Tests/AcceptanceTestsBase.cs
+++ b/src/ProxyKit.Tests/AcceptanceTestsBase.cs
@@ -85,6 +85,28 @@ namespace ProxyKit
             response.Headers.Location.ShouldBe(new Uri($"http://localhost:{ProxyPort}/redirect"));
         }
 
+        [Fact]
+        public async Task When_body_included_with_transfer_encoding_should_get_ok()
+        {
+            var client = CreateClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "/normal")
+            {
+                // This enforces using Transfer-Encoding: chunked
+                Content = new PushStreamContent(async (stream, httpContext, transPortContext) =>
+                {
+                    var buffer = new byte[100];
+                    await stream.WriteAsync(buffer, 0, 100);
+                    await stream.FlushAsync();
+                    stream.Dispose();
+                })
+            };
+            var response = await client.SendAsync(request);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            var readAsByteArrayAsync = await response.Content.ReadAsByteArrayAsync();
+            readAsByteArrayAsync.Length.ShouldBe(100);
+        }
+
         public abstract Task InitializeAsync();
 
         public abstract Task DisposeAsync();
@@ -107,7 +129,13 @@ namespace ProxyKit
                 app.Map("/normal", a => a.Run(async ctx =>
                 {
                     ctx.Response.StatusCode = 200;
-                    await ctx.Response.WriteAsync("Ok");
+                    ctx.Response.ContentLength = ctx.Request.ContentLength;
+                    var buffer = new byte[1024];
+                    var bytesRead = await ctx.Request.Body.ReadAsync(buffer, 0, buffer.Length);
+                    if (bytesRead > 0)
+                    {
+                        await ctx.Response.Body.WriteAsync(buffer, 0, bytesRead);
+                    }
                 }));
 
                 app.Map("/cachable", a => a.Run(async ctx =>

--- a/src/ProxyKit.Tests/AcceptanceTestsBase.cs
+++ b/src/ProxyKit.Tests/AcceptanceTestsBase.cs
@@ -85,13 +85,13 @@ namespace ProxyKit
             response.Headers.Location.ShouldBe(new Uri($"http://localhost:{ProxyPort}/redirect"));
         }
 
-        [Fact]
+        [Fact(Skip = "Passes in kestrel but fails because of bug in TestServer https://github.com/dotnet/aspnetcore/issues/21677")]
         public async Task When_body_included_with_transfer_encoding_should_get_ok()
         {
             var client = CreateClient();
             var request = new HttpRequestMessage(HttpMethod.Post, "/normal")
             {
-                // This enforces using Transfer-Encoding: chunked
+                // This enforces usage of header Transfer-Encoding: chunked
                 Content = new PushStreamContent(async (stream, httpContext, transPortContext) =>
                 {
                     var buffer = new byte[100];

--- a/src/ProxyKit.Tests/AzureTests.cs
+++ b/src/ProxyKit.Tests/AzureTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ProxyKit.Infra;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProxyKit
+{
+    public class AzureTests : IAsyncLifetime
+    {
+        private readonly IWebHost _proxy;
+        private int _port;
+
+        public AzureTests(ITestOutputHelper outputHelper)
+        {
+            _proxy = new WebHostBuilder()
+                .UseStartup<ProxyStartup>()
+                .UseKestrel()
+                .UseUrls("http://*:0")
+                .ConfigureLogging(builder =>
+                {
+                    builder.AddProvider(new XunitLoggerProvider(outputHelper, "Proxy"));
+                    builder.SetMinimumLevel(LogLevel.Debug);
+                })
+                .Build();
+        }
+
+        [Fact]
+        public async Task Can_proxy_azure_app_service()
+        {
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri($"http://localhost:{_port}")
+            };
+
+            var response = await client.GetAsync("");
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task When_body_included_with_transfer_encoding_should_get_bad_gateway()
+        {
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri($"http://localhost:{_port}")
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "")
+            {
+                // This enforces using Transfer-Encoding: chunked
+                Content = new PushStreamContent(async (stream, httpContext, transPortContext) =>
+                {
+                    var buffer = new byte[100];
+                    await stream.WriteAsync(buffer);
+                    await stream.FlushAsync();
+                    stream.Dispose();
+                })
+            };
+            var response = await client.SendAsync(request);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
+        }
+
+        protected class ProxyStartup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddProxy();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                // my blog is currently hosted on azure. If it move this will need to be changed.
+                app.RunProxy(context => context
+                    .ForwardTo("http://dhickey.ie")
+                    .Send());
+            }
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _proxy.StartAsync();
+
+            _port = _proxy.GetServerPort();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _proxy.StopAsync();
+        }
+    }
+
+}

--- a/src/ProxyKit.Tests/ProxyTests.cs
+++ b/src/ProxyKit.Tests/ProxyTests.cs
@@ -257,12 +257,11 @@ namespace ProxyKit
             var server = new TestServer(_builder);
             var client = server.CreateClient();
 
-            var requestMessage = new HttpRequestMessage(new HttpMethod(httpMethod), "http://mydomain.example")
+            var request = new HttpRequestMessage(new HttpMethod(httpMethod), "http://mydomain.example")
             {
-                Content = new StringContent(text)
+                Content = new StringContentWithLength(text)
             };
-
-            await client.SendAsync(requestMessage);
+            await client.SendAsync(request);
             var sentRequest = _testMessageHandler.SentRequestMessages.First();
             var sentContent = sentRequest.Content;
 

--- a/src/ProxyKit.Tests/StringContentWithLength.cs
+++ b/src/ProxyKit.Tests/StringContentWithLength.cs
@@ -1,0 +1,41 @@
+﻿using System.Net.Http;
+using System.Text;
+
+namespace ProxyKit
+{
+    public class StringContentWithLength : StringContent
+    {
+        public StringContentWithLength(string content)
+            : base(content)
+        {
+            EnsureContentLength();
+        }
+
+        public StringContentWithLength(string content, Encoding encoding)
+            : base(content, encoding)
+        {
+            EnsureContentLength();
+        }
+
+        public StringContentWithLength(string content, Encoding encoding, string mediaType)
+            : base(content, encoding, mediaType)
+        {
+            EnsureContentLength();
+        }
+
+        public StringContentWithLength(string content, string unvalidatedContentType)
+            : base(content)
+        {
+            Headers.TryAddWithoutValidation("Content-Type", unvalidatedContentType);
+            EnsureContentLength();
+        }
+
+        private void EnsureContentLength()
+        {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
+            // required due to https://github.com/dotnet/aspnetcore/issues/18463
+            var contentLength = Headers.ContentLength;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
+        }
+    }
+}

--- a/src/ProxyKit/HttpContextExtensions.cs
+++ b/src/ProxyKit/HttpContextExtensions.cs
@@ -51,9 +51,11 @@ namespace ProxyKit
         private static HttpRequestMessage CreateProxyHttpRequest(this HttpRequest request)
         {
             var requestMessage = new HttpRequestMessage();
-            
-            //Only copy Body when original request has a body.
-            if (request.Body.CanRead)
+
+            // The presence of a message-body in a request is signaled by the
+            // inclusion of a Content-Length or Transfer-Encoding header field in
+            // the request's message-headers. https://tools.ietf.org/html/rfc2616 4.3 MessageBody
+            if (request.ContentLength > 0 || request.Headers.ContainsKey("Transfer-Encoding"))
             {
                 var streamContent = new StreamContent(request.Body);
                 requestMessage.Content = streamContent;


### PR DESCRIPTION
Fixes #219 

Use detection of body by checking if `Content-Length` > 0 or the existance of `Transfer-Encoding` header as per https://tools.ietf.org/html/rfc2616#section-4.3 and suggested by @markgould

There is however a problem... during testing I discoved that ANC `TestServer` and it's custom client is not compliant. That is, requests with a body that don't specify a `Content-Length` don't have a `Transfer-Encoding` header and the body will be dropped. https://github.com/dotnet/aspnetcore/issues/21677

TODO for this PR, add some documentation about the TestServer issues.

Was also affected by this https://github.com/dotnet/aspnetcore/issues/18463 where tests weren't setting a Content-Length in the requests to TestServer.